### PR TITLE
Add get_products_sumary endpoint to show product consolidated

### DIFF
--- a/app/api/v1/orders.py
+++ b/app/api/v1/orders.py
@@ -8,7 +8,8 @@ import logging
 from ...schemas.order import (
     OrderCreate, OrderUpdate, OrderResponse, OrderItemCreate,
     OrderAnalyticsSummary, StatusDistributionSummary,
-    BatchOrderUpdateRequest, BatchOrderUpdateResponse
+    BatchOrderUpdateRequest, BatchOrderUpdateResponse,
+    ProductsSummaryResponse
 )
 from ...schemas.payment import PaymentResponse, OrderPaymentSummary
 from ...schemas.pagination import PaginatedResponse
@@ -1239,6 +1240,59 @@ def get_orders_by_route(
         return order_service.get_orders_by_route_analytics(db, year=year)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error getting orders by route: {str(e)}")
+
+
+@router.get("/analytics/products-summary", response_model=ProductsSummaryResponse)
+def get_products_summary(
+        status_filter: Optional[str] = Query(None, description="Filtrar por estado de la orden"),
+        route_id: Optional[int] = Query(None, description="Filtrar por ruta"),
+        date_from: Optional[date] = Query(None, description="Fecha de inicio (YYYY-MM-DD)"),
+        date_to: Optional[date] = Query(None, description="Fecha de fin (YYYY-MM-DD)"),
+        search: Optional[str] = Query(None, description="Buscar por número de orden o nombre de cliente"),
+        db: Session = Depends(get_tenant_db),
+        order_service: OrderService = Depends(get_order_service),
+        current_user: User = Depends(get_current_active_user),
+        request: Request = None):
+    """Consolidado de productos totalizados según filtros.
+
+    Solo incluye órdenes con ruta asignada. Si no se filtra por ruta,
+    agrega los totales de todas las rutas.
+    """
+    if not can_view_orders(current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="No tienes permisos para ver pedidos."
+        )
+
+    try:
+        validate_date_range(date_from, date_to)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    client_timezone = get_request_timezone(request) if request else None
+
+    status_enum = None
+    if status_filter:
+        try:
+            status_enum = OrderStatus(status_filter.lower())
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Estado inválido: {status_filter}"
+            )
+
+    try:
+        return order_service.get_products_summary(
+            db,
+            status=status_enum,
+            route_id=route_id,
+            date_from=date_from,
+            date_to=date_to,
+            search=search,
+            client_timezone=client_timezone,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error generando el consolidado: {str(e)}")
 
 
 @router.get("/analytics/production-forecast")

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -716,3 +716,128 @@ class OrderRepository(BaseRepository[Order, OrderCreate, OrderUpdate]):
             }
             for row in rows
         ]
+
+    def get_products_summary(
+        self,
+        db: Session,
+        *,
+        status: Optional[OrderStatus] = None,
+        route_id: Optional[int] = None,
+        date_from: Optional[date] = None,
+        date_to: Optional[date] = None,
+        search: Optional[str] = None,
+        client_timezone: Optional[str] = None,
+    ) -> dict:
+        """Consolida cantidades y valores de productos según filtros.
+
+        Solo incluye órdenes con ruta asignada (route_id IS NOT NULL).
+        Devuelve lista plana de productos con sus totales y el gran total.
+        """
+        from ..models.product import Product
+        from ..models.route import Route
+        from ..models.client import Client
+        from sqlalchemy import func, text
+
+        filters = [Order.route_id.isnot(None)]
+
+        if status is not None:
+            status_value = status.value if hasattr(status, 'value') else str(status)
+            filters.append(
+                text("orders.status = :status").params(status=status_value.upper())
+            )
+
+        if route_id is not None:
+            filters.append(Order.route_id == route_id)
+
+        if date_from is not None:
+            if client_timezone:
+                filters.append(
+                    text("DATE(orders.created_at AT TIME ZONE :tz) >= :date_from").params(
+                        tz=client_timezone, date_from=date_from
+                    )
+                )
+            else:
+                filters.append(
+                    Order.created_at >= datetime.combine(date_from, datetime.min.time())
+                )
+
+        if date_to is not None:
+            if client_timezone:
+                filters.append(
+                    text("DATE(orders.created_at AT TIME ZONE :tz) <= :date_to").params(
+                        tz=client_timezone, date_to=date_to
+                    )
+                )
+            else:
+                filters.append(
+                    Order.created_at <= datetime.combine(date_to, datetime.max.time())
+                )
+
+        # Query de productos agrupados — select_from(Order) fija la tabla base
+        products_query = (
+            db.query(
+                OrderItem.product_id.label("product_id"),
+                Product.name.label("product_name"),
+                func.sum(OrderItem.quantity).label("total_quantity"),
+                func.sum(OrderItem.total_price).label("total_value"),
+            )
+            .select_from(Order)
+            .join(OrderItem, OrderItem.order_id == Order.id)
+            .join(Product, Product.id == OrderItem.product_id)
+            .join(Route, Route.id == Order.route_id)
+        )
+
+        # Query de total de órdenes distintas (separada para evitar doble conteo)
+        count_query = (
+            db.query(func.count(func.distinct(Order.id)))
+            .select_from(Order)
+            .join(OrderItem, OrderItem.order_id == Order.id)
+            .join(Route, Route.id == Order.route_id)
+        )
+
+        if search is not None and search.strip():
+            search_term = f"%{search.strip()}%"
+            search_filter = or_(
+                Order.order_number.ilike(search_term),
+                Client.name.ilike(search_term),
+            )
+            products_query = (
+                products_query.join(Client, Order.client_id == Client.id)
+                .filter(search_filter)
+            )
+            count_query = (
+                count_query.join(Client, Order.client_id == Client.id)
+                .filter(search_filter)
+            )
+
+        rows = (
+            products_query.filter(and_(*filters))
+            .group_by(OrderItem.product_id, Product.name)
+            .order_by(Product.name)
+            .all()
+        )
+        total_orders = count_query.filter(and_(*filters)).scalar() or 0
+
+        products = [
+            {
+                "product_id": row.product_id,
+                "product_name": row.product_name,
+                "total_quantity": float(row.total_quantity or 0),
+                "total_value": float(row.total_value or 0),
+            }
+            for row in rows
+        ]
+
+        grand_total = sum(p["total_value"] for p in products)
+
+        route_name = None
+        if route_id is not None:
+            route = db.query(Route).filter(Route.id == route_id).first()
+            route_name = route.name if route else None
+
+        return {
+            "products": products,
+            "grand_total_value": grand_total,
+            "total_order_count": total_orders,
+            "route_name": route_name,
+        }

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -214,3 +214,25 @@ class RouteOrdersResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class ProductSummaryItem(BaseModel):
+    """Producto con su cantidad y valor total consolidados"""
+    product_id: int
+    product_name: str
+    total_quantity: float
+    total_value: float
+
+    class Config:
+        from_attributes = True
+
+
+class ProductsSummaryResponse(BaseModel):
+    """Consolidado de productos según filtros activos"""
+    products: List[ProductSummaryItem]
+    grand_total_value: float
+    total_order_count: int
+    route_name: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -843,3 +843,25 @@ class OrderService:
             error_message=error_message,
             products_with_errors=[]
         ))
+
+    def get_products_summary(
+        self,
+        db: Session,
+        *,
+        status: Optional[OrderStatus] = None,
+        route_id: Optional[int] = None,
+        date_from: Optional[date] = None,
+        date_to: Optional[date] = None,
+        search: Optional[str] = None,
+        client_timezone: Optional[str] = None,
+    ) -> dict:
+        """Consolidado de productos por filtros (solo órdenes con ruta asignada)."""
+        return self.order_repository.get_products_summary(
+            db,
+            status=status,
+            route_id=route_id,
+            date_from=date_from,
+            date_to=date_to,
+            search=search,
+            client_timezone=client_timezone,
+        )

--- a/tests/api/orders/test_products_summary.py
+++ b/tests/api/orders/test_products_summary.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for GET /api/v1/orders/analytics/products-summary endpoint.
+
+Covers:
+- Response shape and 200 status
+- Unauthenticated request
+- Empty result when no matching orders
+- Exclusion of orders without route
+- route_id filter
+- status_filter filter
+- date_from / date_to filters
+- Invalid status returns 400
+- Invalid date range returns 400
+"""
+
+import pytest
+from app.models.order import OrderStatus
+
+SUMMARY_URL = "/api/v1/orders/analytics/products-summary"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def route_in_db(setup_factories):
+    from tests.factories import RouteFactory
+    return RouteFactory.create(name="Ruta Norte")
+
+
+@pytest.fixture
+def product_in_db(setup_factories):
+    from tests.factories import ProductFactory
+    return ProductFactory.create(name="Queso Fresco", price=30.0, stock=100, is_active=True)
+
+
+@pytest.fixture
+def order_with_route(setup_factories, route_in_db):
+    """PENDING order with a route and one item."""
+    from tests.factories import ClientFactory, OrderFactory, OrderItemFactory, ProductFactory
+    client = ClientFactory.create()
+    product = ProductFactory.create(price=30.0, stock=100, is_active=True)
+    order = OrderFactory.create(
+        client=client,
+        route=route_in_db,
+        status=OrderStatus.PENDING,
+        total_amount=150.0,
+    )
+    OrderItemFactory.create(order=order, product=product, quantity=5, unit_price=30.0, total_price=150.0)
+    return order
+
+
+@pytest.fixture
+def order_without_route(setup_factories):
+    """Order with route=None — should be excluded from the summary."""
+    from tests.factories import ClientFactory, OrderFactory, OrderItemFactory, ProductFactory
+    client = ClientFactory.create()
+    product = ProductFactory.create(price=30.0, stock=100, is_active=True)
+    order = OrderFactory.create(
+        client=client,
+        route=None,
+        status=OrderStatus.PENDING,
+        total_amount=90.0,
+    )
+    OrderItemFactory.create(order=order, product=product, quantity=3, unit_price=30.0, total_price=90.0)
+    return order
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestProductsSummaryShape:
+
+    def test_returns_200_with_correct_shape(self, authenticated_client, test_user, order_with_route):
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        data = response.json()
+        assert "products" in data
+        assert "grand_total_value" in data
+        assert "total_order_count" in data
+        assert "route_name" in data
+        assert isinstance(data["products"], list)
+
+    def test_product_item_has_correct_fields(self, authenticated_client, test_user, order_with_route):
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        products = response.json()["products"]
+        assert len(products) >= 1
+        item = products[0]
+        assert "product_id" in item
+        assert "product_name" in item
+        assert "total_quantity" in item
+        assert "total_value" in item
+
+    def test_unauthenticated_returns_4xx(self, client):
+        response = client.get(SUMMARY_URL)
+        assert response.status_code in (401, 403)
+
+
+class TestProductsSummaryFiltering:
+
+    def test_empty_result_returns_200_not_404(self, authenticated_client, test_user, setup_factories):
+        """No matching data should return empty list with 200, not 404."""
+        response = authenticated_client.get(SUMMARY_URL, params={"status_filter": "delivered"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["products"] == []
+        assert data["grand_total_value"] == 0.0
+        assert data["total_order_count"] == 0
+
+    def test_excludes_orders_without_route(
+        self, authenticated_client, test_user, order_without_route
+    ):
+        """Orders with route_id=None must not appear in the summary."""
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["products"] == []
+        assert data["total_order_count"] == 0
+
+    def test_includes_orders_with_route(
+        self, authenticated_client, test_user, order_with_route
+    ):
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["products"]) >= 1
+        assert data["total_order_count"] >= 1
+
+    def test_route_id_filter_scopes_to_one_route(
+        self, authenticated_client, test_user, setup_factories, route_in_db
+    ):
+        from tests.factories import ClientFactory, RouteFactory, OrderFactory, OrderItemFactory, ProductFactory
+
+        # Orden en la ruta bajo prueba
+        client_a = ClientFactory.create()
+        product_a = ProductFactory.create(price=10.0, stock=100, is_active=True)
+        order_a = OrderFactory.create(client=client_a, route=route_in_db, status=OrderStatus.PENDING, total_amount=50.0)
+        OrderItemFactory.create(order=order_a, product=product_a, quantity=5, unit_price=10.0, total_price=50.0)
+
+        # Orden en otra ruta
+        other_route = RouteFactory.create(name="Ruta Sur")
+        client_b = ClientFactory.create()
+        product_b = ProductFactory.create(price=20.0, stock=100, is_active=True)
+        order_b = OrderFactory.create(client=client_b, route=other_route, status=OrderStatus.PENDING, total_amount=100.0)
+        OrderItemFactory.create(order=order_b, product=product_b, quantity=5, unit_price=20.0, total_price=100.0)
+
+        response = authenticated_client.get(SUMMARY_URL, params={"route_id": route_in_db.id})
+        assert response.status_code == 200
+        data = response.json()
+
+        # Solo debe aparecer el producto de route_in_db
+        product_ids = [p["product_id"] for p in data["products"]]
+        assert product_a.id in product_ids
+        assert product_b.id not in product_ids
+        assert data["route_name"] == route_in_db.name
+
+    def test_route_name_is_none_when_no_route_filter(
+        self, authenticated_client, test_user, order_with_route
+    ):
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        assert response.json()["route_name"] is None
+
+    def test_status_filter_scopes_results(
+        self, authenticated_client, test_user, setup_factories, route_in_db
+    ):
+        from tests.factories import ClientFactory, OrderFactory, OrderItemFactory, ProductFactory
+
+        # Orden DELIVERED
+        client = ClientFactory.create()
+        product = ProductFactory.create(price=50.0, stock=100, is_active=True)
+        order = OrderFactory.create(
+            client=client, route=route_in_db,
+            status=OrderStatus.DELIVERED, total_amount=100.0
+        )
+        OrderItemFactory.create(order=order, product=product, quantity=2, unit_price=50.0, total_price=100.0)
+
+        # Filtrar por PENDING no debe devolver nada
+        response = authenticated_client.get(SUMMARY_URL, params={"status_filter": "pending"})
+        assert response.status_code == 200
+        assert response.json()["products"] == []
+
+        # Filtrar por DELIVERED debe devolver el producto
+        response = authenticated_client.get(SUMMARY_URL, params={"status_filter": "delivered"})
+        assert response.status_code == 200
+        assert len(response.json()["products"]) >= 1
+
+    def test_quantity_totals_are_aggregated_correctly(
+        self, authenticated_client, test_user, setup_factories, route_in_db
+    ):
+        """Two orders with the same product on the same route must sum quantities."""
+        from tests.factories import ClientFactory, OrderFactory, OrderItemFactory, ProductFactory
+
+        product = ProductFactory.create(name="Queso Duro", price=25.0, stock=200, is_active=True)
+
+        for _ in range(2):
+            client = ClientFactory.create()
+            order = OrderFactory.create(client=client, route=route_in_db, status=OrderStatus.PENDING, total_amount=250.0)
+            OrderItemFactory.create(order=order, product=product, quantity=10, unit_price=25.0, total_price=250.0)
+
+        response = authenticated_client.get(SUMMARY_URL)
+        assert response.status_code == 200
+        products = response.json()["products"]
+        match = next((p for p in products if p["product_id"] == product.id), None)
+        assert match is not None
+        assert match["total_quantity"] == pytest.approx(20.0)
+
+
+class TestProductsSummaryValidation:
+
+    def test_invalid_status_returns_400(self, authenticated_client, test_user):
+        response = authenticated_client.get(SUMMARY_URL, params={"status_filter": "invalid_status"})
+        assert response.status_code == 400
+
+    def test_invalid_date_range_returns_400(self, authenticated_client, test_user):
+        response = authenticated_client.get(
+            SUMMARY_URL,
+            params={"date_from": "2026-06-20", "date_to": "2026-06-01"},
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary
- New endpoint `GET /api/v1/orders/analytics/products-summary` that returns
  product totals (quantity) aggregated from order items, filtered by date,
  route, status, and search.
- Only orders with an assigned route are included (`route_id IS NOT NULL`).
- When no route filter is applied, totals are aggregated across all routes.
- When a specific `route_id` is provided, the response includes `route_name`
  for display purposes.

## Changes
- `app/schemas/order.py` — Added `ProductSummaryItem` and `ProductsSummaryResponse` schemas.
- `app/repositories/order_repository.py` — Added `get_products_summary()` with a
  SQL GROUP BY aggregate query. Uses `.select_from(Order)` to avoid FROM-clause
  ambiguity. Runs a separate COUNT(DISTINCT) query for `total_order_count` to
  avoid double-counting.
- `app/services/order_service.py` — Added pass-through `get_products_summary()`.
- `app/api/v1/orders.py` — Registered the new endpoint in the analytics block.
  Reuses existing `validate_date_range`, `get_request_timezone`, and
  `can_view_orders` helpers. Visible to all roles.

## Tests
- `tests/api/orders/test_products_summary.py` — 12 integration tests covering:
  response shape, unauthenticated access, empty results, route exclusion,
  route/status/date filters, quantity aggregation, and input validation (400s).
